### PR TITLE
Include chunk assets in manifest

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -30,9 +30,9 @@ export default {
       generateBundle(options, bundle) {
         const manifest = {};
         for (const [fileName, chunk] of Object.entries(bundle)) {
-          if (chunk.type === 'chunk' && chunk.isEntry) {
+          if (chunk.type === 'chunk') {
             const isWorker = chunk.facadeModuleId?.includes('/workers/') ?? false;
-            const originalName = `/dist/js/${chunk.name}${isWorker ? '.js' : '.min.js'}`;
+            const originalName = `/dist/js/${chunk.name}${chunk.isEntry ? (isWorker ? '.js' : '.min.js') : '.js'}`;
             manifest[originalName] = `/dist/js/${fileName}`;
           }
         }


### PR DESCRIPTION
## Summary
- include non-entry chunks like utils and services in Rollup manifest

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68bbc8a1e59c8328a0f98c1d4aae4af3