### PR TITLE
feat: use dynamic app version in leg-craft

### DIFF
--- a/leg-craft.html
+++ b/leg-craft.html
@@ -1,14 +1,21 @@
 <!DOCTYPE html>
 <html lang="es">
 <head>
+  <meta name="app-version" content="1.0.0">
+  <script>window.__APP_VERSION__='1.0.0';</script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="icon" href="/img/favicon.ico" sizes="16x16" type="image/x-icon">
   <title>Crafteo de Armas y Armaduras Legendarias – GW2</title>
   <link href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@400;600;700&display=swap" rel="stylesheet">
-  
-  <link rel="stylesheet" href="css/leg-css.css?v=1756274160">
-  <link rel="stylesheet" href="css/global-gw.css?v=1756274160">
+
+  <link id="leg-css" rel="stylesheet">
+  <link id="global-gw-css" rel="stylesheet">
+  <script>
+    const v = window.__APP_VERSION__;
+    document.getElementById('leg-css').href = `css/leg-css.css?v=${v}`;
+    document.getElementById('global-gw-css').href = `css/global-gw.css?v=${v}`;
+  </script>
 <!-- Google tag (gtag.js) -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-1YJ4M39JP3"></script>
 <script>
@@ -156,22 +163,20 @@
   </div>
   </main>
 
-  <script type="module" src="/dist/v1330bcf/bundle-utils-1.By0Xs4MH.min.js?v=1756274160" defer></script>
-  <script type="module" src="/dist/v1330bcf/bundle-auth-nav.CyOGHb8A.min.js?v=1756274160" defer></script>
-  <!-- Consulta dist/manifest.json para obtener el hash actual; se regenera en cada compilación -->
-  <script type="module" src="/dist/v1330bcf/bundle-legendary.DIH8x-x6.min.js?v=1756274160" defer></script>
-  <script>
+  <script type="module">
+    const version = window.__APP_VERSION__;
+    await import(`/dist/${version}/bundle-utils-1.By0Xs4MH.min.js?v=${version}`);
+    await import(`/dist/${version}/bundle-auth-nav.CyOGHb8A.min.js?v=${version}`);
+    await import(`/dist/${version}/bundle-legendary.DIH8x-x6.min.js?v=${version}`);
     // Inicializar autenticación cuando el DOM esté listo
     document.addEventListener('DOMContentLoaded', function() {
       if (window.Auth && typeof window.Auth.initAuth === 'function') {
         window.Auth.initAuth();
       }
     });
+    await import(`/dist/${version}/tabs.DUiiG-cO.min.js?v=${version}`);
+    await import(`/dist/${version}/feedback-modal.BaGBwUid.min.js?v=${version}`);
+    await import(`/dist/${version}/sw-register.Wot8iBZe.min.js?v=${version}`);
   </script>
-  
-  <script type="module" src="/dist/v1330bcf/tabs.DUiiG-cO.min.js?v=1756274160" defer></script>
-  
-  <script type="module" src="/dist/v1330bcf/feedback-modal.BaGBwUid.min.js?v=1756274160" defer></script>
-  <script type="module" src="/dist/v1330bcf/sw-register.Wot8iBZe.min.js?v=1756274160"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- expose app version in leg-craft head and use it to set CSS URLs
- load leg-craft scripts with runtime versioned URLs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bbe1ba278483288a822aed14d70956