### PR TITLE
Use app version variable in compare-craft resources

### DIFF
--- a/compare-craft.html
+++ b/compare-craft.html
@@ -1,11 +1,13 @@
 <!DOCTYPE html>
 <html lang="es">
 <head>
+  <meta name="app-version" content="1.0.0">
+  <script>window.__APP_VERSION__='1.0.0';</script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="icon" href="/img/favicon.ico" sizes="16x16" type="image/x-icon">
   <title>Comparador de Costes de Crafteo – Herramienta GW2</title>
-  <link rel="stylesheet" href="css/global-gw.css?v=1756274160">
+  <link rel="stylesheet" href="css/global-gw.css?v=${window.__APP_VERSION__}">
 <!-- Google tag (gtag.js) -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-1YJ4M39JP3"></script>
 <script>
@@ -72,7 +74,7 @@
 
 
   
-  <script type="module" src="/dist/v1330bcf/bundle-utils-1.By0Xs4MH.min.js?v=1756274160" defer></script>
+  <script type="module" src="/dist/${window.__APP_VERSION__}/bundle-utils-1.By0Xs4MH.min.js?v=${window.__APP_VERSION__}" defer></script>
 
   <!-- Modal del Buscador fuera de .container para igualar a index.html -->
   <div id="search-modal" class="search-modal hidden">
@@ -99,7 +101,7 @@
     const closeBtn = document.getElementById('close-search-modal');
     openBtn.addEventListener('click', function(e) {
       e.preventDefault();
-      openSearchModal('/dist/v1330bcf/search-modal-compare-craft.Ds_WAp9-.min.js?v=1756274160');
+      openSearchModal(`/dist/${window.__APP_VERSION__}/search-modal-compare-craft.Ds_WAp9-.min.js?v=${window.__APP_VERSION__}`);
     });
     closeBtn.addEventListener('click', closeSearchModal);
     modal.querySelector('.search-modal-backdrop').addEventListener('click', closeSearchModal);
@@ -109,10 +111,10 @@
   });
   </script>
 
-  <script type="module" src="/dist/v1330bcf/tabs.DUiiG-cO.min.js?v=1756274160" defer></script>
-  <script type="module" src="/dist/v1330bcf/feedback-modal.BaGBwUid.min.js?v=1756274160" defer></script>
+  <script type="module" src="/dist/${window.__APP_VERSION__}/tabs.DUiiG-cO.min.js?v=${window.__APP_VERSION__}" defer></script>
+  <script type="module" src="/dist/${window.__APP_VERSION__}/feedback-modal.BaGBwUid.min.js?v=${window.__APP_VERSION__}" defer></script>
   <!-- Nuevos módulos separados -->
-  <script type="module" src="/dist/v1330bcf/items-core.DMXEDbc5.min.js?v=1756274160" defer></script>
+  <script type="module" src="/dist/${window.__APP_VERSION__}/items-core.DMXEDbc5.min.js?v=${window.__APP_VERSION__}" defer></script>
   <script type="module" src="/dist/js/ui-helpers.min.js" defer></script>
   <script type="module" src="/dist/js/compare-ui.min.js" defer></script>
 
@@ -143,7 +145,7 @@
 };
 
   </script>
-<script type="module" src="/dist/v1330bcf/bundle-auth-nav.CyOGHb8A.min.js?v=1756274160" defer></script>
+<script type="module" src="/dist/${window.__APP_VERSION__}/bundle-auth-nav.CyOGHb8A.min.js?v=${window.__APP_VERSION__}" defer></script>
 <script>
   // Inicializar autenticación cuando el DOM esté listo
   document.addEventListener('DOMContentLoaded', function() {
@@ -164,6 +166,6 @@
     }
   });
 </script>
-  <script type="module" src="/dist/v1330bcf/sw-register.Wot8iBZe.min.js?v=1756274160"></script>
+  <script type="module" src="/dist/${window.__APP_VERSION__}/sw-register.Wot8iBZe.min.js?v=${window.__APP_VERSION__}"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- reference global app version in compare-craft head metadata
- load search modal and bundled scripts using window.__APP_VERSION__
- replace hard-coded version query strings across compare-craft resources

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bbe1bf18748328834299c8a1a9e89b