### PR TITLE
Purge prior CDN assets and document automated purge

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Run `npm run build` to regenerate the bundles. Before compiling it removes any p
 ### Build y despliegue
 
 1. Ejecuta `npm run build` para generar los bundles. Este comando limpia `dist/`, calcula `APP_VERSION` y compila los archivos en `dist/<APP_VERSION>/`.
-2. Al finalizar, el script `postbuild` invoca `scripts/purge-cdn.js` para invalidar caches de Cloudflare. Define `CLOUDFLARE_ZONE_ID` y `CLOUDFLARE_TOKEN` en el entorno para que la operación tenga éxito.
+2. Al finalizar, el script `postbuild` invoca `scripts/purge-cdn.js` y elimina en Cloudflare las rutas de la versión anterior. Define `CLOUDFLARE_ZONE_ID`, `CLOUDFLARE_TOKEN` y `CLOUDFLARE_BASE_URL` en el entorno para que la operación tenga éxito.
 3. Publica el contenido de `dist/` en tu servidor o CDN. Los recursos incluyen hashes, se ubican bajo `dist/<APP_VERSION>/` y deben servirse con `Cache-Control: no-cache`.
 
 Include the bundles from `/dist/<APP_VERSION>/` in your HTML pages. Los nombres incluyen un hash y pueden consultarse en `dist/manifest.json`:
@@ -35,7 +35,7 @@ Las pruebas sólo requieren Node.js y las dependencias instaladas (`mongodb` y `
 
 ## Despliegue
 
-Los archivos HTML referencian recursos con hash y se sirven con `Cache-Control: no-cache` para que los navegadores obtengan siempre la versión más reciente. Tras cada despliegue, invalida las cachés de la CDN o de Cloudflare para forzar la actualización de estos archivos.
+Los archivos HTML referencian recursos con hash y se sirven con `Cache-Control: no-cache` para que los navegadores obtengan siempre la versión más reciente. El script `scripts/deploy.sh` llama automáticamente a `scripts/purge-cdn.js`, que calcula las rutas de la versión previa y las purga en Cloudflare para que los cambios se propaguen de inmediato.
 
 After loading `/dist/js/bundle-legendary.<hash>.min.js` (consulta `dist/manifest.json` para obtener el hash actual) a global object `window.LegendaryData` becomes available with the following properties:
 

--- a/scripts/check-assets.js
+++ b/scripts/check-assets.js
@@ -9,12 +9,13 @@ const missing = [];
 for (const htmlFile of htmlFiles) {
   const filePath = path.join(rootDir, htmlFile);
   const content = fs.readFileSync(filePath, 'utf8');
-  const matches = content.match(/\/dist\/js\/[^"'\s)]+\.js/g) || [];
+  const matches = content.match(/\/dist\/js\/[^"'\s)]+\.js[^"'\s)]*/g) || [];
   for (const ref of new Set(matches)) {
-    const relative = ref.replace(/^\//, '');
+    const [cleanRef] = ref.split('?');
+    const relative = cleanRef.replace(/^\//, '');
     const assetPath = path.join(rootDir, relative);
     if (!fs.existsSync(assetPath)) {
-      missing.push(`${ref} referenced in ${htmlFile}`);
+      missing.push(`${cleanRef} referenced in ${htmlFile}`);
     }
   }
 }

--- a/scripts/purge-cdn.js
+++ b/scripts/purge-cdn.js
@@ -1,12 +1,25 @@
-const fetch = global.fetch || ((...args) => import('node-fetch').then(({default: f}) => f(...args)));
+const fetch = global.fetch || ((...args) => import('node-fetch').then(({ default: f }) => f(...args)));
+const { execSync } = require('child_process');
 
 const zone = process.env.CLOUDFLARE_ZONE_ID;
 const token = process.env.CLOUDFLARE_TOKEN;
+const baseUrl = process.env.CLOUDFLARE_BASE_URL;
 
-if (!zone || !token) {
-  console.error('CLOUDFLARE_ZONE_ID and CLOUDFLARE_TOKEN env vars are required');
+if (!zone || !token || !baseUrl) {
+  console.error('CLOUDFLARE_ZONE_ID, CLOUDFLARE_TOKEN and CLOUDFLARE_BASE_URL env vars are required');
   process.exit(1);
 }
+
+let urls = [];
+try {
+  const prevManifestRaw = execSync('git show HEAD^:dist/manifest.json', { encoding: 'utf8' });
+  const prevManifest = JSON.parse(prevManifestRaw);
+  urls = [...new Set(Object.values(prevManifest))].map((p) => `${baseUrl.replace(/\/$/, '')}${p}`);
+} catch (e) {
+  console.warn('Previous manifest not found, purging everything');
+}
+
+const payload = urls.length > 0 ? { files: urls } : { purge_everything: true };
 
 fetch(`https://api.cloudflare.com/client/v4/zones/${zone}/purge_cache`, {
   method: 'POST',
@@ -14,7 +27,7 @@ fetch(`https://api.cloudflare.com/client/v4/zones/${zone}/purge_cache`, {
     'Content-Type': 'application/json',
     Authorization: `Bearer ${token}`,
   },
-  body: JSON.stringify({ purge_everything: true }),
+  body: JSON.stringify(payload),
 })
   .then((r) => r.json())
   .then((res) => {
@@ -22,7 +35,9 @@ fetch(`https://api.cloudflare.com/client/v4/zones/${zone}/purge_cache`, {
       console.error('CDN purge failed', res.errors);
       process.exit(1);
     }
-    console.log('CDN cache purged');
+    console.log(
+      payload.purge_everything ? 'CDN cache purged (everything)' : `Purged ${urls.length} paths from previous version`
+    );
   })
   .catch((err) => {
     console.error('CDN purge failed', err);


### PR DESCRIPTION
## Summary
- Ignore query strings when verifying asset files.
- Purge only previous version paths on Cloudflare using manifest history.
- Document automated CDN purge and required variables in deployment guide.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bbe3801b548328bb2de62285701ed8