### PR TITLE
feat: add SRI hashing and versioned source maps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+dist/
+packages/*/node_modules/

--- a/docs/integrity-debugging.md
+++ b/docs/integrity-debugging.md
@@ -1,0 +1,27 @@
+# Verificación de integridad y acceso a *source maps*
+
+El proceso de *build* genera hashes SRI (`sha256` y `sha384`) para los
+recursos JavaScript y CSS. Los valores se anexan automáticamente en los
+atributos `integrity` de las etiquetas `<script>` y `<link>`, junto con
+`crossorigin="anonymous"`. Los navegadores verifican estos hashes antes de
+ejecutar o aplicar los archivos, garantizando que no fueron alterados.
+
+Para comprobar manualmente la integridad de un archivo se puede ejecutar:
+
+```bash
+openssl dgst -sha256 -binary archivo | openssl base64 -A
+```
+
+## *Source maps*
+
+Se generan *source maps* por cada `build` con el nombre `*.v<version>.js.map`.
+El destino se controla con la variable de entorno `SOURCE_MAP_TARGET`:
+
+- `cdn` (por defecto): los mapas permanecen junto a los bundles y pueden
+  subirse a la CDN.
+- `internal`: los mapas se mueven a `dist/<version>/sourcemaps/` para alojarlos
+  en un servidor interno.
+
+Los bundles apuntan automáticamente al nombre y ubicación correctos mediante
+`//# sourceMappingURL=...`. Para depurar basta con acceder al mapa generado
+de la versión correspondiente.

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -67,6 +67,7 @@ export default {
   output: {
     dir: `dist/${appVersion}`,
     format: 'es',
+    sourcemap: true,
     entryFileNames: (chunkInfo) =>
       chunkInfo.facadeModuleId.includes('/workers/')
         ? '[name].[hash].js'

--- a/scripts/update-html.js
+++ b/scripts/update-html.js
@@ -1,5 +1,6 @@
 const fs = require('fs');
 const path = require('path');
+const crypto = require('crypto');
 
 const manifestPath = path.join(__dirname, '..', 'dist', 'manifest.json');
 if (!fs.existsSync(manifestPath)) {
@@ -17,6 +18,54 @@ try {
 
 const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
 const rootDir = path.join(__dirname, '..');
+const distVersionDir = path.join(rootDir, 'dist', version);
+
+// SRI hashes for produced assets
+const sriMap = {};
+for (const hashed of Object.values(manifest)) {
+  const assetPath = path.join(rootDir, hashed);
+  if (fs.existsSync(assetPath)) {
+    const buf = fs.readFileSync(assetPath);
+    const sha256 = crypto.createHash('sha256').update(buf).digest('base64');
+    const sha384 = crypto.createHash('sha384').update(buf).digest('base64');
+    sriMap[hashed] = `sha256-${sha256} sha384-${sha384}`;
+  }
+}
+// Also compute SRI for CSS files
+const cssDir = path.join(rootDir, 'css');
+if (fs.existsSync(cssDir)) {
+  const cssFiles = fs.readdirSync(cssDir).filter(f => f.endsWith('.css'));
+  for (const file of cssFiles) {
+    const relPath = path.join('css', file);
+    const buf = fs.readFileSync(path.join(rootDir, relPath));
+    const sha256 = crypto.createHash('sha256').update(buf).digest('base64');
+    const sha384 = crypto.createHash('sha384').update(buf).digest('base64');
+    sriMap[relPath] = `sha256-${sha256} sha384-${sha384}`;
+  }
+}
+
+// Rename source maps with version and optionally move them
+const sourcemapTarget = process.env.SOURCE_MAP_TARGET || 'cdn';
+if (fs.existsSync(distVersionDir)) {
+  const mapFiles = fs.readdirSync(distVersionDir).filter(f => f.endsWith('.js.map'));
+  for (const map of mapFiles) {
+    const srcPath = path.join(distVersionDir, map);
+    const versioned = map.replace(/\.js\.map$/, `.v${version}.js.map`);
+    const targetDir = sourcemapTarget === 'cdn' ? distVersionDir : path.join(distVersionDir, 'sourcemaps');
+    fs.mkdirSync(targetDir, { recursive: true });
+    const destPath = path.join(targetDir, versioned);
+    fs.renameSync(srcPath, destPath);
+    // Update JS file to point to the renamed map
+    const jsFile = path.join(distVersionDir, map.replace(/\.map$/, ''));
+    if (fs.existsSync(jsFile)) {
+      let jsContent = fs.readFileSync(jsFile, 'utf8');
+      const mapRef = sourcemapTarget === 'cdn' ? versioned : `sourcemaps/${versioned}`;
+      jsContent = jsContent.replace(/\/\/\# sourceMappingURL=[^\n]+/, `//# sourceMappingURL=${mapRef}`);
+      fs.writeFileSync(jsFile, jsContent);
+    }
+  }
+}
+
 const htmlFiles = fs.readdirSync(rootDir).filter(f => f.endsWith('.html'));
 
 for (const file of htmlFiles) {
@@ -40,6 +89,33 @@ for (const file of htmlFiles) {
     updated = updated.replace(/<meta name="app-version" content="[^"]*">/, metaTag);
     updated = updated.replace(/window.__APP_VERSION__='[^']*';/, `window.__APP_VERSION__='${version}';`);
   }
+  // Add SRI attributes for scripts
+  updated = updated.replace(/<script[^>]+src="([^"]+)"[^>]*><\/script>/g, (tag, src) => {
+    const cleanSrc = src.split('?')[0];
+    const integrity = sriMap[cleanSrc];
+    if (integrity) {
+      if (tag.includes('integrity=')) {
+        tag = tag.replace(/integrity="[^"]*"/, `integrity="${integrity}"`);
+      } else {
+        tag = tag.replace('<script', `<script integrity="${integrity}" crossorigin="anonymous"`);
+      }
+    }
+    return tag;
+  });
+  // Add SRI attributes for CSS links
+  updated = updated.replace(/<link[^>]+href="([^"]+)"[^>]*>/g, (tag, href) => {
+    const cleanHref = href.split('?')[0];
+    const integrity = sriMap[cleanHref];
+    if (integrity) {
+      if (tag.includes('integrity=')) {
+        tag = tag.replace(/integrity="[^"]*"/, `integrity="${integrity}"`);
+      } else {
+        tag = tag.replace('<link', `<link integrity="${integrity}" crossorigin="anonymous"`);
+      }
+    }
+    return tag;
+  });
+
   if (updated !== content) {
     fs.writeFileSync(filePath, updated);
   }


### PR DESCRIPTION
## Summary
- add sourcemap generation and versioning
- compute SRI hashes for JS and CSS and inject into HTML
- document integrity verification and sourcemap hosting

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bc5e5765248328a2296590a01aa6ad