### PR TITLE
feat: improve asset checks and CDN purge

### DIFF
--- a/scripts/check-assets.js
+++ b/scripts/check-assets.js
@@ -9,9 +9,9 @@ const missing = [];
 for (const htmlFile of htmlFiles) {
   const filePath = path.join(rootDir, htmlFile);
   const content = fs.readFileSync(filePath, 'utf8');
-  const matches = content.match(/\/dist\/js\/[^"'\s)]+\.js[^"'\s)]*/g) || [];
+  const matches = content.match(/\/dist\/[^/"'\s)]+\/[^"'\s)]+\.js(?:\?v=[^"'\s)]*)?/g) || [];
   for (const ref of new Set(matches)) {
-    const [cleanRef] = ref.split('?');
+    const cleanRef = ref.replace(/\?v=[^"'\s)]*/, '');
     const relative = cleanRef.replace(/^\//, '');
     const assetPath = path.join(rootDir, relative);
     if (!fs.existsSync(assetPath)) {


### PR DESCRIPTION
## Summary
- handle versioned `/dist/<version>/` assets and strip `?v=` for existence checks
- derive previous dist version to build CDN purge URLs without `manifest.json`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bc7559b8708328b0009297951a388b