### PR TITLE
chore: automate version tagging and changelog in CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,4 +30,5 @@ jobs:
           git add CHANGELOG.md
           VERSION=$(node -p "require('./package.json').version")
           git commit -m "chore(changelog): update changelog for v$VERSION"
+          git tag -f v$VERSION
       - run: git push --follow-tags

--- a/README.md
+++ b/README.md
@@ -22,9 +22,9 @@ La CDN de Cloudflare ignora los query strings al construir la clave de caché, p
 
 ## Versionado
 
-Ejecuta `npm run version:patch`, `npm run version:minor` o `npm run version:major` para actualizar `package.json` y `version.txt`. Estos comandos crean un tag y el CI generará el changelog correspondiente.
+Ejecuta `npm run version:patch`, `npm run version:minor` o `npm run version:major` para actualizar `package.json` y `version.txt`. Cada comando invoca `scripts/update-version-txt.js`, crea un commit etiquetado y el flujo de CI genera el changelog correspondiente.
 
-Disparadores:
+Disparadores (`release_type` en el workflow `release`):
 
 - **PATCH**: cualquier cambio bajo `dist/` sin API pública nueva.
 - **MINOR**: nuevas funcionalidades o bundles compatibles.

--- a/package.json
+++ b/package.json
@@ -13,9 +13,9 @@
     "bump:cache": "bash scripts/bump-cache-version.sh",
     "purge:cdn": "node scripts/purge-cdn.js",
     "version": "node scripts/update-version-txt.js",
-    "version:patch": "npm version patch",
-    "version:minor": "npm version minor",
-    "version:major": "npm version major"
+    "version:patch": "npm version patch -m \"chore(release): v%s\"",
+    "version:minor": "npm version minor -m \"chore(release): v%s\"",
+    "version:major": "npm version major -m \"chore(release): v%s\""
   },
   "dependencies": {
     "mongodb": "^6.5.0",


### PR DESCRIPTION
## Summary
- tag version commits with `npm version` scripts
- retag release workflow after updating changelog
- document release triggers and versioning flow

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bc76652fa48328870f2d4805706d43