### PR TITLE
fix: use global css on guides page

### DIFF
--- a/guias.html
+++ b/guias.html
@@ -7,9 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="icon" href="/img/favicon.ico" sizes="16x16" type="image/x-icon">
   <title>Tablero de Videos - GW2</title>
-  <link rel="stylesheet" href="css/global.css?v=1.0.0">
-  <link rel="stylesheet" href="css/styles-2.css?v=1.0.0">
-  <link rel="stylesheet" href="css/index.css?v=1.0.0">
+  <link integrity="sha256-3KTGYB1FxMzkVqLV4zcAvVqwAMJWbsPxPT44jS0fUXk= sha384-oOV6TGLGOB+l2btdKi1rjgcdp5GrniPY9tUpd1v1UqfZHQcCV9yb7nrrf7ls9S9n" crossorigin="anonymous" rel="stylesheet" href="css/global-gw.css?v=1.0.0">
 <!-- Google tag (gtag.js) -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-1YJ4M39JP3"></script>
 <script>


### PR DESCRIPTION
## Summary
- replace outdated css links on guides page with existing global stylesheet

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bcdf4b59f8832891683411e118357e