### PR TITLE
build: keep tabs and search modal core filenames stable

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -5,7 +5,15 @@ import { minify } from 'terser';
 
 const pkg = JSON.parse(readFileSync(new URL('./package.json', import.meta.url)));
 const appVersion = process.env.APP_VERSION || pkg.version;
-const noHashEntries = new Set(['ui-helpers', 'compare-ui', 'storageUtils', 'compareHandlers', 'cuenta']);
+const noHashEntries = new Set([
+  'ui-helpers',
+  'compare-ui',
+  'storageUtils',
+  'compareHandlers',
+  'cuenta',
+  'tabs',
+  'search-modal-core'
+]);
 
 export default {
   // Entradas separadas para cada vista o funcionalidad pesada


### PR DESCRIPTION
## Summary
- keep `tabs` and `search-modal-core` bundles unhashed so they emit predictable names

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bd20a9894883288275d3e6d6f9328e