### PR TITLE
feat: build and deploy html assets

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -6,10 +6,14 @@ TARGET=/var/www/gw2
 RELEASE=${1:-$(git rev-parse --short HEAD)}
 KEEP=${KEEP:-3}
 
+cd "$ROOT"
+npm run build
+
 mkdir -p "$TARGET/releases/$RELEASE"
 # Bundles are versioned in dist/<APP_VERSION>/ to avoid cache issues.
 # Copy the entire dist tree so each release has its own assets.
 cp -a dist/. "$TARGET/releases/$RELEASE/"
+cp -a ./*.html "$TARGET/releases/$RELEASE/"
 ln -sfn "$TARGET/releases/$RELEASE" "$TARGET/current"
 
 cd "$TARGET/releases"


### PR DESCRIPTION
## Summary
- build project before deployment to ensure assets and HTML are up to date
- copy HTML files to the release directory alongside the dist tree

## Testing
- `npm test`
- verified SRI hashes in HTML against `openssl` (css matched, js assets reported mismatches)


------
https://chatgpt.com/codex/tasks/task_e_68bdb6b023708328b466b5fc91264fa0