### PR TITLE
feat: verify html asset integrity

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "build:packages": "npm --prefix packages/recipe-nesting run build && npm --prefix packages/recipe-calculation run build",
     "postbuild": "node scripts/update-html.js && npm run purge:cdn",
     "check-assets": "node scripts/check-assets.js",
+    "check-integrity": "node scripts/check-integrity.js",
     "bump:cache": "bash scripts/bump-cache-version.sh",
     "purge:cdn": "node scripts/purge-cdn.js",
     "version": "node scripts/update-version-txt.js",

--- a/scripts/check-integrity.js
+++ b/scripts/check-integrity.js
@@ -1,0 +1,95 @@
+const fs = require('fs');
+const path = require('path');
+const crypto = require('crypto');
+const fetch = global.fetch || ((...args) => import('node-fetch').then(({ default: f }) => f(...args)));
+
+const rootDir = path.join(__dirname, '..');
+
+function getHtmlFiles(dir) {
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+  const files = [];
+  for (const entry of entries) {
+    if (entry.isDirectory()) {
+      if (entry.name === 'node_modules' || entry.name === '.git') {
+        continue;
+      }
+      files.push(...getHtmlFiles(path.join(dir, entry.name)));
+    } else if (entry.isFile() && entry.name.endsWith('.html')) {
+      files.push(path.join(dir, entry.name));
+    }
+  }
+  return files;
+}
+
+async function computeHash(ref, baseDir) {
+  const cleanRef = ref.split(/[?#]/)[0];
+  if (/^https?:\/\//i.test(cleanRef) || cleanRef.startsWith('//')) {
+    const url = cleanRef.startsWith('//') ? `https:${cleanRef}` : cleanRef;
+    const res = await fetch(url);
+    if (!res.ok) {
+      throw new Error(`HTTP ${res.status}`);
+    }
+    const buffer = Buffer.from(await res.arrayBuffer());
+    return crypto.createHash('sha384').update(buffer).digest('base64');
+  }
+  const target = cleanRef.startsWith('/')
+    ? path.join(rootDir, cleanRef)
+    : path.join(baseDir, cleanRef);
+  const buffer = fs.readFileSync(target);
+  return crypto.createHash('sha384').update(buffer).digest('base64');
+}
+
+async function checkFile(filePath) {
+  const content = fs.readFileSync(filePath, 'utf8');
+  const tagRegex = /<(script|link)[^>]+>/gi;
+  const failures = [];
+  let tagMatch;
+  while ((tagMatch = tagRegex.exec(content)) !== null) {
+    const tag = tagMatch[0];
+    const attrRegex = /([a-zA-Z0-9_-]+)=["']([^"']+)["']/g;
+    const attrs = {};
+    let attrMatch;
+    while ((attrMatch = attrRegex.exec(tag)) !== null) {
+      attrs[attrMatch[1]] = attrMatch[2];
+    }
+    const ref = attrs.src || attrs.href;
+    const integrity = attrs.integrity;
+    if (!ref || !integrity) {
+      continue;
+    }
+    const parts = integrity.split(/\s+/);
+    const sha384Part = parts.find(p => p.startsWith('sha384-'));
+    if (!sha384Part) {
+      failures.push(`${path.relative(rootDir, filePath)} -> ${ref} missing sha384`);
+      continue;
+    }
+    const expected = sha384Part.split('-')[1];
+    try {
+      const actual = await computeHash(ref, path.dirname(filePath));
+      if (actual !== expected) {
+        failures.push(`${path.relative(rootDir, filePath)} -> ${ref}`);
+      }
+    } catch (err) {
+      failures.push(`${path.relative(rootDir, filePath)} -> ${ref} (${err.message})`);
+    }
+  }
+  return failures;
+}
+
+(async () => {
+  const htmlFiles = getHtmlFiles(rootDir);
+  const allFailures = [];
+  for (const file of htmlFiles) {
+    const failures = await checkFile(file);
+    allFailures.push(...failures);
+  }
+  if (allFailures.length > 0) {
+    console.error('Integrity mismatches:');
+    for (const f of allFailures) {
+      console.error(' -', f);
+    }
+    process.exit(1);
+  } else {
+    console.log('All integrity hashes match.');
+  }
+})();

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -19,5 +19,7 @@ ln -sfn "$TARGET/releases/$RELEASE" "$TARGET/current"
 cd "$TARGET/releases"
 ls -1t | tail -n +$((KEEP+1)) | xargs -r rm -rf
 
+npm --prefix "$ROOT" run check-integrity
+
 # Purge CDN cache to force revalidation of assets
 node "$ROOT/scripts/purge-cdn.js"


### PR DESCRIPTION
## Summary
- add script to validate integrity hashes of linked assets in HTML files
- run integrity check after deploy before CDN purge

## Testing
- `npm test`
- `npm run check-integrity` *(fails: Integrity mismatches for multiple resources)*

------
https://chatgpt.com/codex/tasks/task_e_68bdb8aa060c83288d6e085dcf3a185c