### PR TITLE
fix: include dones script in bundle

### DIFF
--- a/src/js/bundle-dones.js
+++ b/src/js/bundle-dones.js
@@ -1,3 +1,4 @@
+import './dones.js';
 import fetchWithRetry from './utils/fetchWithRetry.js';
 // Bundled dones core and tabs
 (function(){


### PR DESCRIPTION
## Summary
- import the dones module into the dones bundle so pages can access `DonesPages`

## Testing
- `npm run build`
- `rg -o "window.DonesPages={" dist/1.0.0/bundle-dones.BbQzldgw.min.js`
- ⚠️ `npm install puppeteer --no-save` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68bdda8dab6083289d989f25f68b9ee7