### PR TITLE
feat: load auth-nav bundle via manifest

### DIFF
--- a/aurene.html
+++ b/aurene.html
@@ -81,15 +81,8 @@
   
     </main>
   </div>
-  <script integrity="sha256-e3+Ub3bujqc4mStLmN8oZtYHu4uZJPmYXFRju6AA6Q8= sha384-sjiNyBsvrZbgC7jV9c37FhMUW3NlFS5w2nNigt+nYWUXUPVQazy72nAB86+1MXxn" crossorigin="anonymous" type="module" src="/dist/1.0.0/bundle-auth-nav.CqVBeA8h.min.js?v=1.0.0"></script>
-  <script>
-    // Inicializar autenticación cuando el DOM esté listo
-    document.addEventListener('DOMContentLoaded', function() {
-      if (window.Auth && typeof window.Auth.initAuth === 'function') {
-        window.Auth.initAuth();
-      }
-    });
-  </script>
+  <script integrity="sha256-+bpdjbsjdfS0DsObGV+H5ase5TcRhNbnugV/kPVkOZM= sha384-DF8o1TAyg7iGs+xFx+N04xQpcAVmwBFH8gGs0gK9kBbGB4GreifwOLYeWpmhO5yX" crossorigin="anonymous" type="module" src="/dist/1.0.0/auth-nav.min.js?v=1.0.0"></script>
+
   
   <script integrity="sha256-yI6ViVC5KFzl3iJ0vTf6VBnEz4JVDaVP7w/3PC3JtYU= sha384-1SklEHhqxptmXw2WXnv8CR0286+EboqTElpLhFpB1AvjirN2PhxYi2ldKS2TvJzy" crossorigin="anonymous" type="module" src="/dist/1.0.0/feedback-modal.BaGBwUid.min.js?v=1.0.0"></script>
   <script integrity="sha256-FxLx+TVwUhON5UhF8ODw/UZ34gLsNlgyBGOTHEpSXrM= sha384-mP/SQYle5qV13Ergl1Q8JsstSEkgoty171bfXnrSAV7Zsv/BmMzB0+m5d/IrJj4K" crossorigin="anonymous" type="module" src="/dist/1.0.0/sw-register.Wot8iBZe.min.js?v=1.0.0"></script>

--- a/builds.html
+++ b/builds.html
@@ -77,15 +77,8 @@
       </section>
     </main>
   </div>
-  <script integrity="sha256-e3+Ub3bujqc4mStLmN8oZtYHu4uZJPmYXFRju6AA6Q8= sha384-sjiNyBsvrZbgC7jV9c37FhMUW3NlFS5w2nNigt+nYWUXUPVQazy72nAB86+1MXxn" crossorigin="anonymous" type="module" src="/dist/1.0.0/bundle-auth-nav.CqVBeA8h.min.js?v=1.0.0"></script>
-  <script>
-    // Inicializar autenticación cuando el DOM esté listo
-    document.addEventListener('DOMContentLoaded', function() {
-      if (window.Auth && typeof window.Auth.initAuth === 'function') {
-        window.Auth.initAuth();
-      }
-    });
-  </script>
+  <script integrity="sha256-+bpdjbsjdfS0DsObGV+H5ase5TcRhNbnugV/kPVkOZM= sha384-DF8o1TAyg7iGs+xFx+N04xQpcAVmwBFH8gGs0gK9kBbGB4GreifwOLYeWpmhO5yX" crossorigin="anonymous" type="module" src="/dist/1.0.0/auth-nav.min.js?v=1.0.0"></script>
+
   
   <script integrity="sha256-yI6ViVC5KFzl3iJ0vTf6VBnEz4JVDaVP7w/3PC3JtYU= sha384-1SklEHhqxptmXw2WXnv8CR0286+EboqTElpLhFpB1AvjirN2PhxYi2ldKS2TvJzy" crossorigin="anonymous" type="module" src="/dist/1.0.0/feedback-modal.BaGBwUid.min.js?v=1.0.0"></script>
   <script integrity="sha256-FxLx+TVwUhON5UhF8ODw/UZ34gLsNlgyBGOTHEpSXrM= sha384-mP/SQYle5qV13Ergl1Q8JsstSEkgoty171bfXnrSAV7Zsv/BmMzB0+m5d/IrJj4K" crossorigin="anonymous" type="module" src="/dist/1.0.0/sw-register.Wot8iBZe.min.js?v=1.0.0"></script>

--- a/compare-craft.html
+++ b/compare-craft.html
@@ -145,15 +145,8 @@
 };
 
   </script>
-<script integrity="sha256-e3+Ub3bujqc4mStLmN8oZtYHu4uZJPmYXFRju6AA6Q8= sha384-sjiNyBsvrZbgC7jV9c37FhMUW3NlFS5w2nNigt+nYWUXUPVQazy72nAB86+1MXxn" crossorigin="anonymous" type="module" src="/dist/1.0.0/bundle-auth-nav.CqVBeA8h.min.js?v=1.0.0" defer></script>
-<script>
-  // Inicializar autenticación cuando el DOM esté listo
-  document.addEventListener('DOMContentLoaded', function() {
-    if (window.Auth && typeof window.Auth.initAuth === 'function') {
-      window.Auth.initAuth();
-    }
-  });
-</script>
+<script integrity="sha256-+bpdjbsjdfS0DsObGV+H5ase5TcRhNbnugV/kPVkOZM= sha384-DF8o1TAyg7iGs+xFx+N04xQpcAVmwBFH8gGs0gK9kBbGB4GreifwOLYeWpmhO5yX" crossorigin="anonymous" type="module" src="/dist/1.0.0/auth-nav.min.js?v=1.0.0"></script>
+
 
 <script integrity="sha256-8rzUVrydB/9DUgSVg6mR2c2b34qWoLOeYP6f/3AVxXE= sha384-iv4HJ9zKO6XQwh0LYh2YP8SXcf36V0pA2YRCWVyEYcJHjR8SZcXw34JYqnBgyCI9" crossorigin="anonymous" type="module" src="/dist/1.0.0/storageUtils.min.js?v=1.0.0" defer></script>
 <!-- Manejadores de comparativa (guardar comparativa) -->

--- a/cuenta.html
+++ b/cuenta.html
@@ -102,15 +102,8 @@
   </div>
 
   <!-- Scripts -->
-  <script integrity="sha256-e3+Ub3bujqc4mStLmN8oZtYHu4uZJPmYXFRju6AA6Q8= sha384-sjiNyBsvrZbgC7jV9c37FhMUW3NlFS5w2nNigt+nYWUXUPVQazy72nAB86+1MXxn" crossorigin="anonymous" type="module" src="/dist/1.0.0/bundle-auth-nav.CqVBeA8h.min.js?v=1.0.0"></script>
-  <script>
-    // Inicializar autenticación cuando el DOM esté listo
-    document.addEventListener('DOMContentLoaded', function() {
-      if (window.Auth && typeof window.Auth.initAuth === 'function') {
-        window.Auth.initAuth();
-      }
-    });
-  </script>
+  <script integrity="sha256-+bpdjbsjdfS0DsObGV+H5ase5TcRhNbnugV/kPVkOZM= sha384-DF8o1TAyg7iGs+xFx+N04xQpcAVmwBFH8gGs0gK9kBbGB4GreifwOLYeWpmhO5yX" crossorigin="anonymous" type="module" src="/dist/1.0.0/auth-nav.min.js?v=1.0.0"></script>
+
   
   <script integrity="sha256-8rzUVrydB/9DUgSVg6mR2c2b34qWoLOeYP6f/3AVxXE= sha384-iv4HJ9zKO6XQwh0LYh2YP8SXcf36V0pA2YRCWVyEYcJHjR8SZcXw34JYqnBgyCI9" crossorigin="anonymous" type="module" src="/dist/1.0.0/storageUtils.min.js?v=1.0.0"></script>
   <script integrity="sha256-8tSn9ajIU3FXoBDFna8ad/qTfYka2QuRwnbkWo21Vhc= sha384-N+y6VzU2gLRRv3X9DdSVhioevDPtdtBzUMlIetQGatbLZVOVUD4FxBtCr1ObITjV" crossorigin="anonymous" type="module" src="/dist/1.0.0/cuenta.min.js?v=1.0.0"></script>

--- a/dist/1.0.0/auth-nav.min.js
+++ b/dist/1.0.0/auth-nav.min.js
@@ -1,0 +1,2 @@
+window.addEventListener("DOMContentLoaded",async()=>{try{const n=(await fetch("/dist/manifest.json").then(n=>n.json()))["/dist/js/bundle-auth-nav.min.js"];n&&await import(`${n}?v=${window.__APP_VERSION__}`)}catch(n){console.error("Error loading auth module",n)}});
+//# sourceMappingURL=auth-nav.min.v1.0.0.js.map

--- a/dist/manifest.json
+++ b/dist/manifest.json
@@ -1,4 +1,5 @@
 {
+  "/dist/js/auth-nav.min.js": "/dist/1.0.0/auth-nav.min.js",
   "/dist/js/tabs.min.js": "/dist/1.0.0/tabs.min.js",
   "/dist/js/search-modal-core.min.js": "/dist/1.0.0/search-modal-core.min.js",
   "/dist/js/storageUtils.min.js": "/dist/1.0.0/storageUtils.min.js",

--- a/dominios.html
+++ b/dominios.html
@@ -70,15 +70,7 @@
       </section>
     </main>
   </div>
-  <script integrity="sha256-e3+Ub3bujqc4mStLmN8oZtYHu4uZJPmYXFRju6AA6Q8= sha384-sjiNyBsvrZbgC7jV9c37FhMUW3NlFS5w2nNigt+nYWUXUPVQazy72nAB86+1MXxn" crossorigin="anonymous" type="module" src="/dist/1.0.0/bundle-auth-nav.CqVBeA8h.min.js?v=1.0.0"></script>
-  <script>
-    // Inicializar autenticación cuando el DOM esté listo
-    document.addEventListener('DOMContentLoaded', function() {
-      if (window.Auth && typeof window.Auth.initAuth === 'function') {
-        window.Auth.initAuth();
-      }
-    });
-  </script>
+  <script integrity="sha256-+bpdjbsjdfS0DsObGV+H5ase5TcRhNbnugV/kPVkOZM= sha384-DF8o1TAyg7iGs+xFx+N04xQpcAVmwBFH8gGs0gK9kBbGB4GreifwOLYeWpmhO5yX" crossorigin="anonymous" type="module" src="/dist/1.0.0/auth-nav.min.js?v=1.0.0"></script>
   
   <script integrity="sha256-yI6ViVC5KFzl3iJ0vTf6VBnEz4JVDaVP7w/3PC3JtYU= sha384-1SklEHhqxptmXw2WXnv8CR0286+EboqTElpLhFpB1AvjirN2PhxYi2ldKS2TvJzy" crossorigin="anonymous" type="module" src="/dist/1.0.0/feedback-modal.BaGBwUid.min.js?v=1.0.0"></script>
   <script integrity="sha256-FxLx+TVwUhON5UhF8ODw/UZ34gLsNlgyBGOTHEpSXrM= sha384-mP/SQYle5qV13Ergl1Q8JsstSEkgoty171bfXnrSAV7Zsv/BmMzB0+m5d/IrJj4K" crossorigin="anonymous" type="module" src="/dist/1.0.0/sw-register.Wot8iBZe.min.js?v=1.0.0"></script>

--- a/dones.html
+++ b/dones.html
@@ -119,15 +119,8 @@
   <script integrity="sha256-UCnHFrhtuBbwVskZQ15SknUgMCEkdf8yeV72rpcDHvs= sha384-MR4plL2WAG8desJ6hzMqDtUafk/BcHQffXcek2RU+FtCCizRN7SoZNV7YcvCTKnX" crossorigin="anonymous" type="module" src="/dist/1.0.0/bundle-dones.C1qPLcjI.min.js?v=1.0.0" defer></script>
   <!-- Consulta dist/manifest.json para obtener el hash actual; se regenera en cada compilación -->
   <script integrity="sha256-wfhiI+tR3hfC2wB86KO9kaAJjaymiSbZOA0BJ7GsaXo= sha384-YQSCQABt9Wboooq73rIu+DLEZNIm5LN9mfsnPH7q8bv+9jA6U/wp6tZpot6UuiiR" crossorigin="anonymous" type="module" src="/dist/1.0.0/bundle-legendary.B3CHYxWY.min.js?v=1.0.0" defer></script>
-  <script integrity="sha256-e3+Ub3bujqc4mStLmN8oZtYHu4uZJPmYXFRju6AA6Q8= sha384-sjiNyBsvrZbgC7jV9c37FhMUW3NlFS5w2nNigt+nYWUXUPVQazy72nAB86+1MXxn" crossorigin="anonymous" type="module" src="/dist/1.0.0/bundle-auth-nav.CqVBeA8h.min.js?v=1.0.0" defer></script>
-  <script>
-    // Inicializar autenticación cuando el DOM esté listo
-    document.addEventListener('DOMContentLoaded', function() {
-      if (window.Auth && typeof window.Auth.initAuth === 'function') {
-        window.Auth.initAuth();
-      }
-    });
-  </script>
+  <script integrity="sha256-+bpdjbsjdfS0DsObGV+H5ase5TcRhNbnugV/kPVkOZM= sha384-DF8o1TAyg7iGs+xFx+N04xQpcAVmwBFH8gGs0gK9kBbGB4GreifwOLYeWpmhO5yX" crossorigin="anonymous" type="module" src="/dist/1.0.0/auth-nav.min.js?v=1.0.0"></script>
+
   
   <script type="module">
     window.addEventListener('DOMContentLoaded', async () => {

--- a/end-game.html
+++ b/end-game.html
@@ -95,15 +95,8 @@
       });
     });
   </script>
-  <script integrity="sha256-e3+Ub3bujqc4mStLmN8oZtYHu4uZJPmYXFRju6AA6Q8= sha384-sjiNyBsvrZbgC7jV9c37FhMUW3NlFS5w2nNigt+nYWUXUPVQazy72nAB86+1MXxn" crossorigin="anonymous" type="module" src="/dist/1.0.0/bundle-auth-nav.CqVBeA8h.min.js?v=1.0.0"></script>
-  <script>
-    // Inicializar autenticación cuando el DOM esté listo
-    document.addEventListener('DOMContentLoaded', function() {
-      if (window.Auth && typeof window.Auth.initAuth === 'function') {
-        window.Auth.initAuth();
-      }
-    });
-  </script>
+  <script integrity="sha256-+bpdjbsjdfS0DsObGV+H5ase5TcRhNbnugV/kPVkOZM= sha384-DF8o1TAyg7iGs+xFx+N04xQpcAVmwBFH8gGs0gK9kBbGB4GreifwOLYeWpmhO5yX" crossorigin="anonymous" type="module" src="/dist/1.0.0/auth-nav.min.js?v=1.0.0"></script>
+
   
   <script integrity="sha256-yI6ViVC5KFzl3iJ0vTf6VBnEz4JVDaVP7w/3PC3JtYU= sha384-1SklEHhqxptmXw2WXnv8CR0286+EboqTElpLhFpB1AvjirN2PhxYi2ldKS2TvJzy" crossorigin="anonymous" type="module" src="/dist/1.0.0/feedback-modal.BaGBwUid.min.js?v=1.0.0"></script>
   <script integrity="sha256-FxLx+TVwUhON5UhF8ODw/UZ34gLsNlgyBGOTHEpSXrM= sha384-mP/SQYle5qV13Ergl1Q8JsstSEkgoty171bfXnrSAV7Zsv/BmMzB0+m5d/IrJj4K" crossorigin="anonymous" type="module" src="/dist/1.0.0/sw-register.Wot8iBZe.min.js?v=1.0.0"></script>

--- a/end-of-dragons.html
+++ b/end-of-dragons.html
@@ -70,15 +70,8 @@
       </section>
     </main>
   </div>
-  <script integrity="sha256-e3+Ub3bujqc4mStLmN8oZtYHu4uZJPmYXFRju6AA6Q8= sha384-sjiNyBsvrZbgC7jV9c37FhMUW3NlFS5w2nNigt+nYWUXUPVQazy72nAB86+1MXxn" crossorigin="anonymous" type="module" src="/dist/1.0.0/bundle-auth-nav.CqVBeA8h.min.js?v=1.0.0"></script>
-  <script>
-    // Inicializar autenticación cuando el DOM esté listo
-    document.addEventListener('DOMContentLoaded', function() {
-      if (window.Auth && typeof window.Auth.initAuth === 'function') {
-        window.Auth.initAuth();
-      }
-    });
-  </script>
+  <script integrity="sha256-+bpdjbsjdfS0DsObGV+H5ase5TcRhNbnugV/kPVkOZM= sha384-DF8o1TAyg7iGs+xFx+N04xQpcAVmwBFH8gGs0gK9kBbGB4GreifwOLYeWpmhO5yX" crossorigin="anonymous" type="module" src="/dist/1.0.0/auth-nav.min.js?v=1.0.0"></script>
+
   
   <script integrity="sha256-yI6ViVC5KFzl3iJ0vTf6VBnEz4JVDaVP7w/3PC3JtYU= sha384-1SklEHhqxptmXw2WXnv8CR0286+EboqTElpLhFpB1AvjirN2PhxYi2ldKS2TvJzy" crossorigin="anonymous" type="module" src="/dist/1.0.0/feedback-modal.BaGBwUid.min.js?v=1.0.0"></script>
   <script integrity="sha256-FxLx+TVwUhON5UhF8ODw/UZ34gLsNlgyBGOTHEpSXrM= sha384-mP/SQYle5qV13Ergl1Q8JsstSEkgoty171bfXnrSAV7Zsv/BmMzB0+m5d/IrJj4K" crossorigin="anonymous" type="module" src="/dist/1.0.0/sw-register.Wot8iBZe.min.js?v=1.0.0"></script>

--- a/forja-mistica.html
+++ b/forja-mistica.html
@@ -224,15 +224,8 @@
   <script integrity="sha256-87vo3JTQvR8hiUpIET/1Sw8hG7NMdlSnMBO2PGBqSGI= sha384-7U8R/Hcnm6vIX8XXkf5zMCs3QJqpLnGD3e8H7qX8bwmEghlNbKI41bc8MbwvzUCw" crossorigin="anonymous" type="module" src="/dist/1.0.0/bundle-utils-1.B5CUuO5Q.min.js?v=1.0.0" defer></script>
   <script integrity="sha256-sSYe36Ppke3VlFyDd2ybJf6m6OCCFDDkIqA7x4i6AQY= sha384-pM1rkIFevGHSBGiO8bIUzeWGz9ALncaqodQ7jOlIhX2TUmxTSPQhURLQieiv1npG" crossorigin="anonymous" type="module" src="/dist/1.0.0/tabs.min.js?v=1.0.0" defer></script>
   <script integrity="sha256-yu2sKmiS9cMdltUJERgQSe24b+OOqB3jqP5tbHPEsrQ= sha384-hvQUkjx0KjWUQe1hWZXieuuD+DVSzz2H57w1mmc43gIXUPtS9HTvLMczqGYvMoZE" crossorigin="anonymous" type="module" src="/dist/1.0.0/bundle-forja-mistica.CTa9lvQ5.min.js?v=1.0.0" defer></script>
-  <script integrity="sha256-e3+Ub3bujqc4mStLmN8oZtYHu4uZJPmYXFRju6AA6Q8= sha384-sjiNyBsvrZbgC7jV9c37FhMUW3NlFS5w2nNigt+nYWUXUPVQazy72nAB86+1MXxn" crossorigin="anonymous" type="module" src="/dist/1.0.0/bundle-auth-nav.CqVBeA8h.min.js?v=1.0.0" defer></script>
-  <script>
-    // Inicializar autenticación cuando el DOM esté listo
-    document.addEventListener('DOMContentLoaded', function() {
-      if (window.Auth && typeof window.Auth.initAuth === 'function') {
-        window.Auth.initAuth();
-      }
-    });
-  </script>
+  <script integrity="sha256-+bpdjbsjdfS0DsObGV+H5ase5TcRhNbnugV/kPVkOZM= sha384-DF8o1TAyg7iGs+xFx+N04xQpcAVmwBFH8gGs0gK9kBbGB4GreifwOLYeWpmhO5yX" crossorigin="anonymous" type="module" src="/dist/1.0.0/auth-nav.min.js?v=1.0.0"></script>
+
 
   <script integrity="sha256-yI6ViVC5KFzl3iJ0vTf6VBnEz4JVDaVP7w/3PC3JtYU= sha384-1SklEHhqxptmXw2WXnv8CR0286+EboqTElpLhFpB1AvjirN2PhxYi2ldKS2TvJzy" crossorigin="anonymous" type="module" src="/dist/1.0.0/feedback-modal.BaGBwUid.min.js?v=1.0.0" defer></script>
   <script integrity="sha256-FxLx+TVwUhON5UhF8ODw/UZ34gLsNlgyBGOTHEpSXrM= sha384-mP/SQYle5qV13Ergl1Q8JsstSEkgoty171bfXnrSAV7Zsv/BmMzB0+m5d/IrJj4K" crossorigin="anonymous" type="module" src="/dist/1.0.0/sw-register.Wot8iBZe.min.js?v=1.0.0"></script>

--- a/fractales-gold.html
+++ b/fractales-gold.html
@@ -208,15 +208,8 @@
       await renderTodo();
     });
   </script>
-  <script integrity="sha256-e3+Ub3bujqc4mStLmN8oZtYHu4uZJPmYXFRju6AA6Q8= sha384-sjiNyBsvrZbgC7jV9c37FhMUW3NlFS5w2nNigt+nYWUXUPVQazy72nAB86+1MXxn" crossorigin="anonymous" type="module" src="/dist/1.0.0/bundle-auth-nav.CqVBeA8h.min.js?v=1.0.0" defer></script>
-  <script>
-    // Inicializar autenticación cuando el DOM esté listo
-    document.addEventListener('DOMContentLoaded', function() {
-      if (window.Auth && typeof window.Auth.initAuth === 'function') {
-        window.Auth.initAuth();
-      }
-    });
-  </script>
+  <script integrity="sha256-+bpdjbsjdfS0DsObGV+H5ase5TcRhNbnugV/kPVkOZM= sha384-DF8o1TAyg7iGs+xFx+N04xQpcAVmwBFH8gGs0gK9kBbGB4GreifwOLYeWpmhO5yX" crossorigin="anonymous" type="module" src="/dist/1.0.0/auth-nav.min.js?v=1.0.0"></script>
+  
   
   <script integrity="sha256-yI6ViVC5KFzl3iJ0vTf6VBnEz4JVDaVP7w/3PC3JtYU= sha384-1SklEHhqxptmXw2WXnv8CR0286+EboqTElpLhFpB1AvjirN2PhxYi2ldKS2TvJzy" crossorigin="anonymous" type="module" src="/dist/1.0.0/feedback-modal.BaGBwUid.min.js?v=1.0.0" defer></script>
   <script integrity="sha256-FxLx+TVwUhON5UhF8ODw/UZ34gLsNlgyBGOTHEpSXrM= sha384-mP/SQYle5qV13Ergl1Q8JsstSEkgoty171bfXnrSAV7Zsv/BmMzB0+m5d/IrJj4K" crossorigin="anonymous" type="module" src="/dist/1.0.0/sw-register.Wot8iBZe.min.js?v=1.0.0"></script>

--- a/guias.html
+++ b/guias.html
@@ -65,15 +65,8 @@
       </section>
     </main>
   </div>
-  <script integrity="sha256-e3+Ub3bujqc4mStLmN8oZtYHu4uZJPmYXFRju6AA6Q8= sha384-sjiNyBsvrZbgC7jV9c37FhMUW3NlFS5w2nNigt+nYWUXUPVQazy72nAB86+1MXxn" crossorigin="anonymous" type="module" src="/dist/1.0.0/bundle-auth-nav.CqVBeA8h.min.js?v=1.0.0"></script>
-  <script>
-    // Inicializar autenticación cuando el DOM esté listo
-    document.addEventListener('DOMContentLoaded', function() {
-      if (window.Auth && typeof window.Auth.initAuth === 'function') {
-        window.Auth.initAuth();
-      }
-    });
-  </script>
+  <script integrity="sha256-+bpdjbsjdfS0DsObGV+H5ase5TcRhNbnugV/kPVkOZM= sha384-DF8o1TAyg7iGs+xFx+N04xQpcAVmwBFH8gGs0gK9kBbGB4GreifwOLYeWpmhO5yX" crossorigin="anonymous" type="module" src="/dist/1.0.0/auth-nav.min.js?v=1.0.0"></script>
+
   
   <script integrity="sha256-yI6ViVC5KFzl3iJ0vTf6VBnEz4JVDaVP7w/3PC3JtYU= sha384-1SklEHhqxptmXw2WXnv8CR0286+EboqTElpLhFpB1AvjirN2PhxYi2ldKS2TvJzy" crossorigin="anonymous" type="module" src="/dist/1.0.0/feedback-modal.BaGBwUid.min.js?v=1.0.0"></script>
   <script integrity="sha256-FxLx+TVwUhON5UhF8ODw/UZ34gLsNlgyBGOTHEpSXrM= sha384-mP/SQYle5qV13Ergl1Q8JsstSEkgoty171bfXnrSAV7Zsv/BmMzB0+m5d/IrJj4K" crossorigin="anonymous" type="module" src="/dist/1.0.0/sw-register.Wot8iBZe.min.js?v=1.0.0"></script>

--- a/index.html
+++ b/index.html
@@ -311,16 +311,7 @@
       grid.appendChild(div);
     });
   </script>
-  <script type="module">
-    window.addEventListener('DOMContentLoaded', async () => {
-      try {
-        await import(`/dist/1.0.0/bundle-auth-nav.CqVBeA8h.min.js?v=1.0.0`);
-        window.Auth?.initAuth?.();
-      } catch (e) {
-        console.error('Error loading auth module', e);
-      }
-    });
-  </script>
+  <script integrity="sha256-+bpdjbsjdfS0DsObGV+H5ase5TcRhNbnugV/kPVkOZM= sha384-DF8o1TAyg7iGs+xFx+N04xQpcAVmwBFH8gGs0gK9kBbGB4GreifwOLYeWpmhO5yX" crossorigin="anonymous" type="module" src="/dist/1.0.0/auth-nav.min.js?v=1.0.0"></script>
   
   <script>
     // Mostrar contenido tras 4 segundos y oscurecer video

--- a/item.html
+++ b/item.html
@@ -116,15 +116,8 @@
   });
   </script>
 
-<script integrity="sha256-e3+Ub3bujqc4mStLmN8oZtYHu4uZJPmYXFRju6AA6Q8= sha384-sjiNyBsvrZbgC7jV9c37FhMUW3NlFS5w2nNigt+nYWUXUPVQazy72nAB86+1MXxn" crossorigin="anonymous" type="module" src="/dist/1.0.0/bundle-auth-nav.CqVBeA8h.min.js?v=1.0.0" defer></script>
-<script>
-  // Inicializar autenticación cuando el DOM esté listo
-  document.addEventListener('DOMContentLoaded', function() {
-    if (window.Auth && typeof window.Auth.initAuth === 'function') {
-      window.Auth.initAuth();
-    }
-  });
-</script>
+<script integrity="sha256-+bpdjbsjdfS0DsObGV+H5ase5TcRhNbnugV/kPVkOZM= sha384-DF8o1TAyg7iGs+xFx+N04xQpcAVmwBFH8gGs0gK9kBbGB4GreifwOLYeWpmhO5yX" crossorigin="anonymous" type="module" src="/dist/1.0.0/auth-nav.min.js?v=1.0.0"></script>
+
 
 <script integrity="sha256-yI6ViVC5KFzl3iJ0vTf6VBnEz4JVDaVP7w/3PC3JtYU= sha384-1SklEHhqxptmXw2WXnv8CR0286+EboqTElpLhFpB1AvjirN2PhxYi2ldKS2TvJzy" crossorigin="anonymous" type="module" src="/dist/1.0.0/feedback-modal.BaGBwUid.min.js?v=1.0.0" defer></script>
 <script integrity="sha256-sSYe36Ppke3VlFyDd2ybJf6m6OCCFDDkIqA7x4i6AQY= sha384-pM1rkIFevGHSBGiO8bIUzeWGz9ALncaqodQ7jOlIhX2TUmxTSPQhURLQieiv1npG" crossorigin="anonymous" type="module" src="/dist/1.0.0/tabs.min.js?v=1.0.0" defer></script>

--- a/janthir-wilds.html
+++ b/janthir-wilds.html
@@ -56,15 +56,8 @@
       </section>
     </main>
   </div>
-  <script integrity="sha256-e3+Ub3bujqc4mStLmN8oZtYHu4uZJPmYXFRju6AA6Q8= sha384-sjiNyBsvrZbgC7jV9c37FhMUW3NlFS5w2nNigt+nYWUXUPVQazy72nAB86+1MXxn" crossorigin="anonymous" type="module" src="/dist/1.0.0/bundle-auth-nav.CqVBeA8h.min.js?v=1.0.0"></script>
-  <script>
-    // Inicializar autenticación cuando el DOM esté listo
-    document.addEventListener('DOMContentLoaded', function() {
-      if (window.Auth && typeof window.Auth.initAuth === 'function') {
-        window.Auth.initAuth();
-      }
-    });
-  </script>
+  <script integrity="sha256-+bpdjbsjdfS0DsObGV+H5ase5TcRhNbnugV/kPVkOZM= sha384-DF8o1TAyg7iGs+xFx+N04xQpcAVmwBFH8gGs0gK9kBbGB4GreifwOLYeWpmhO5yX" crossorigin="anonymous" type="module" src="/dist/1.0.0/auth-nav.min.js?v=1.0.0"></script>
+
   
   <script integrity="sha256-yI6ViVC5KFzl3iJ0vTf6VBnEz4JVDaVP7w/3PC3JtYU= sha384-1SklEHhqxptmXw2WXnv8CR0286+EboqTElpLhFpB1AvjirN2PhxYi2ldKS2TvJzy" crossorigin="anonymous" type="module" src="/dist/1.0.0/feedback-modal.BaGBwUid.min.js?v=1.0.0"></script>
   <script integrity="sha256-FxLx+TVwUhON5UhF8ODw/UZ34gLsNlgyBGOTHEpSXrM= sha384-mP/SQYle5qV13Ergl1Q8JsstSEkgoty171bfXnrSAV7Zsv/BmMzB0+m5d/IrJj4K" crossorigin="anonymous" type="module" src="/dist/1.0.0/sw-register.Wot8iBZe.min.js?v=1.0.0"></script>

--- a/leg-craft.html
+++ b/leg-craft.html
@@ -166,17 +166,11 @@
   <script type="module">
     const version = window.__APP_VERSION__;
     await import(`/dist/${version}/bundle-utils-1.B5CUuO5Q.min.js?v=${version}`);
-    await import(`/dist/${version}/bundle-auth-nav.CqVBeA8h.min.js?v=${version}`);
     await import(`/dist/${version}/bundle-legendary.B3CHYxWY.min.js?v=${version}`);
-    // Inicializar autenticación cuando el DOM esté listo
-    document.addEventListener('DOMContentLoaded', function() {
-      if (window.Auth && typeof window.Auth.initAuth === 'function') {
-        window.Auth.initAuth();
-      }
-    });
     await import(`/dist/${version}/tabs.min.js?v=${version}`);
     await import(`/dist/${version}/feedback-modal.BaGBwUid.min.js?v=${version}`);
     await import(`/dist/${version}/sw-register.Wot8iBZe.min.js?v=${version}`);
   </script>
+  <script integrity="sha256-+bpdjbsjdfS0DsObGV+H5ase5TcRhNbnugV/kPVkOZM= sha384-DF8o1TAyg7iGs+xFx+N04xQpcAVmwBFH8gGs0gK9kBbGB4GreifwOLYeWpmhO5yX" crossorigin="anonymous" type="module" src="/dist/1.0.0/auth-nav.min.js?v=1.0.0"></script>
 </body>
 </html>

--- a/legendarios.html
+++ b/legendarios.html
@@ -326,15 +326,8 @@ function scrollToLegendario(id) {
 
     </main>
   </div>
-  <script integrity="sha256-e3+Ub3bujqc4mStLmN8oZtYHu4uZJPmYXFRju6AA6Q8= sha384-sjiNyBsvrZbgC7jV9c37FhMUW3NlFS5w2nNigt+nYWUXUPVQazy72nAB86+1MXxn" crossorigin="anonymous" type="module" src="/dist/1.0.0/bundle-auth-nav.CqVBeA8h.min.js?v=1.0.0"></script>
-  <script>
-    // Inicializar autenticación cuando el DOM esté listo
-    document.addEventListener('DOMContentLoaded', function() {
-      if (window.Auth && typeof window.Auth.initAuth === 'function') {
-        window.Auth.initAuth();
-      }
-    });
-  </script>
+  <script integrity="sha256-+bpdjbsjdfS0DsObGV+H5ase5TcRhNbnugV/kPVkOZM= sha384-DF8o1TAyg7iGs+xFx+N04xQpcAVmwBFH8gGs0gK9kBbGB4GreifwOLYeWpmhO5yX" crossorigin="anonymous" type="module" src="/dist/1.0.0/auth-nav.min.js?v=1.0.0"></script>
+
   
   <script integrity="sha256-yI6ViVC5KFzl3iJ0vTf6VBnEz4JVDaVP7w/3PC3JtYU= sha384-1SklEHhqxptmXw2WXnv8CR0286+EboqTElpLhFpB1AvjirN2PhxYi2ldKS2TvJzy" crossorigin="anonymous" type="module" src="/dist/1.0.0/feedback-modal.BaGBwUid.min.js?v=1.0.0"></script>
   <script integrity="sha256-FxLx+TVwUhON5UhF8ODw/UZ34gLsNlgyBGOTHEpSXrM= sha384-mP/SQYle5qV13Ergl1Q8JsstSEkgoty171bfXnrSAV7Zsv/BmMzB0+m5d/IrJj4K" crossorigin="anonymous" type="module" src="/dist/1.0.0/sw-register.Wot8iBZe.min.js?v=1.0.0"></script>

--- a/login.html
+++ b/login.html
@@ -73,15 +73,8 @@
         </p>
         <p style="margin-top:20px;"><a href="/">Volver al inicio</a></p>
     </div>
-    <script integrity="sha256-e3+Ub3bujqc4mStLmN8oZtYHu4uZJPmYXFRju6AA6Q8= sha384-sjiNyBsvrZbgC7jV9c37FhMUW3NlFS5w2nNigt+nYWUXUPVQazy72nAB86+1MXxn" crossorigin="anonymous" type="module" src="/dist/1.0.0/bundle-auth-nav.CqVBeA8h.min.js?v=1.0.0"></script>
-    <script>
-      // Inicializar autenticación cuando el DOM esté listo
-      document.addEventListener('DOMContentLoaded', function() {
-        if (window.Auth && typeof window.Auth.initAuth === 'function') {
-          window.Auth.initAuth();
-        }
-      });
-    </script>
+    <script integrity="sha256-+bpdjbsjdfS0DsObGV+H5ase5TcRhNbnugV/kPVkOZM= sha384-DF8o1TAyg7iGs+xFx+N04xQpcAVmwBFH8gGs0gK9kBbGB4GreifwOLYeWpmhO5yX" crossorigin="anonymous" type="module" src="/dist/1.0.0/auth-nav.min.js?v=1.0.0"></script>
+
   <script integrity="sha256-FxLx+TVwUhON5UhF8ODw/UZ34gLsNlgyBGOTHEpSXrM= sha384-mP/SQYle5qV13Ergl1Q8JsstSEkgoty171bfXnrSAV7Zsv/BmMzB0+m5d/IrJj4K" crossorigin="anonymous" type="module" src="/dist/1.0.0/sw-register.Wot8iBZe.min.js?v=1.0.0"></script>
 </body>
 </html>

--- a/lore.html
+++ b/lore.html
@@ -68,15 +68,8 @@
      
     </main>
   </div>
-  <script integrity="sha256-e3+Ub3bujqc4mStLmN8oZtYHu4uZJPmYXFRju6AA6Q8= sha384-sjiNyBsvrZbgC7jV9c37FhMUW3NlFS5w2nNigt+nYWUXUPVQazy72nAB86+1MXxn" crossorigin="anonymous" type="module" src="/dist/1.0.0/bundle-auth-nav.CqVBeA8h.min.js?v=1.0.0"></script>
-  <script>
-    // Inicializar autenticación cuando el DOM esté listo
-    document.addEventListener('DOMContentLoaded', function() {
-      if (window.Auth && typeof window.Auth.initAuth === 'function') {
-        window.Auth.initAuth();
-      }
-    });
-  </script>
+  <script integrity="sha256-+bpdjbsjdfS0DsObGV+H5ase5TcRhNbnugV/kPVkOZM= sha384-DF8o1TAyg7iGs+xFx+N04xQpcAVmwBFH8gGs0gK9kBbGB4GreifwOLYeWpmhO5yX" crossorigin="anonymous" type="module" src="/dist/1.0.0/auth-nav.min.js?v=1.0.0"></script>
+  
   
   <script integrity="sha256-yI6ViVC5KFzl3iJ0vTf6VBnEz4JVDaVP7w/3PC3JtYU= sha384-1SklEHhqxptmXw2WXnv8CR0286+EboqTElpLhFpB1AvjirN2PhxYi2ldKS2TvJzy" crossorigin="anonymous" type="module" src="/dist/1.0.0/feedback-modal.BaGBwUid.min.js?v=1.0.0"></script>
   <script integrity="sha256-FxLx+TVwUhON5UhF8ODw/UZ34gLsNlgyBGOTHEpSXrM= sha384-mP/SQYle5qV13Ergl1Q8JsstSEkgoty171bfXnrSAV7Zsv/BmMzB0+m5d/IrJj4K" crossorigin="anonymous" type="module" src="/dist/1.0.0/sw-register.Wot8iBZe.min.js?v=1.0.0"></script>

--- a/mundo-viviente-3.html
+++ b/mundo-viviente-3.html
@@ -78,15 +78,8 @@
       </section>
     </main>
   </div>
-  <script integrity="sha256-e3+Ub3bujqc4mStLmN8oZtYHu4uZJPmYXFRju6AA6Q8= sha384-sjiNyBsvrZbgC7jV9c37FhMUW3NlFS5w2nNigt+nYWUXUPVQazy72nAB86+1MXxn" crossorigin="anonymous" type="module" src="/dist/1.0.0/bundle-auth-nav.CqVBeA8h.min.js?v=1.0.0"></script>
-  <script>
-    // Inicializar autenticación cuando el DOM esté listo
-    document.addEventListener('DOMContentLoaded', function() {
-      if (window.Auth && typeof window.Auth.initAuth === 'function') {
-        window.Auth.initAuth();
-      }
-    });
-  </script>
+  <script integrity="sha256-+bpdjbsjdfS0DsObGV+H5ase5TcRhNbnugV/kPVkOZM= sha384-DF8o1TAyg7iGs+xFx+N04xQpcAVmwBFH8gGs0gK9kBbGB4GreifwOLYeWpmhO5yX" crossorigin="anonymous" type="module" src="/dist/1.0.0/auth-nav.min.js?v=1.0.0"></script>
+
   
   <script integrity="sha256-yI6ViVC5KFzl3iJ0vTf6VBnEz4JVDaVP7w/3PC3JtYU= sha384-1SklEHhqxptmXw2WXnv8CR0286+EboqTElpLhFpB1AvjirN2PhxYi2ldKS2TvJzy" crossorigin="anonymous" type="module" src="/dist/1.0.0/feedback-modal.BaGBwUid.min.js?v=1.0.0"></script>
   <script integrity="sha256-FxLx+TVwUhON5UhF8ODw/UZ34gLsNlgyBGOTHEpSXrM= sha384-mP/SQYle5qV13Ergl1Q8JsstSEkgoty171bfXnrSAV7Zsv/BmMzB0+m5d/IrJj4K" crossorigin="anonymous" type="module" src="/dist/1.0.0/sw-register.Wot8iBZe.min.js?v=1.0.0"></script>

--- a/mundo-viviente-4.html
+++ b/mundo-viviente-4.html
@@ -75,15 +75,8 @@
       </section>
     </main>
   </div>
-  <script integrity="sha256-e3+Ub3bujqc4mStLmN8oZtYHu4uZJPmYXFRju6AA6Q8= sha384-sjiNyBsvrZbgC7jV9c37FhMUW3NlFS5w2nNigt+nYWUXUPVQazy72nAB86+1MXxn" crossorigin="anonymous" type="module" src="/dist/1.0.0/bundle-auth-nav.CqVBeA8h.min.js?v=1.0.0"></script>
-  <script>
-    // Inicializar autenticación cuando el DOM esté listo
-    document.addEventListener('DOMContentLoaded', function() {
-      if (window.Auth && typeof window.Auth.initAuth === 'function') {
-        window.Auth.initAuth();
-      }
-    });
-  </script>
+  <script integrity="sha256-+bpdjbsjdfS0DsObGV+H5ase5TcRhNbnugV/kPVkOZM= sha384-DF8o1TAyg7iGs+xFx+N04xQpcAVmwBFH8gGs0gK9kBbGB4GreifwOLYeWpmhO5yX" crossorigin="anonymous" type="module" src="/dist/1.0.0/auth-nav.min.js?v=1.0.0"></script>
+
   
   <script integrity="sha256-yI6ViVC5KFzl3iJ0vTf6VBnEz4JVDaVP7w/3PC3JtYU= sha384-1SklEHhqxptmXw2WXnv8CR0286+EboqTElpLhFpB1AvjirN2PhxYi2ldKS2TvJzy" crossorigin="anonymous" type="module" src="/dist/1.0.0/feedback-modal.BaGBwUid.min.js?v=1.0.0"></script>
   <script integrity="sha256-FxLx+TVwUhON5UhF8ODw/UZ34gLsNlgyBGOTHEpSXrM= sha384-mP/SQYle5qV13Ergl1Q8JsstSEkgoty171bfXnrSAV7Zsv/BmMzB0+m5d/IrJj4K" crossorigin="anonymous" type="module" src="/dist/1.0.0/sw-register.Wot8iBZe.min.js?v=1.0.0"></script>

--- a/politica-privacidad.html
+++ b/politica-privacidad.html
@@ -80,7 +80,7 @@
         <p>Si tienes dudas sobre esta política, puedes contactarnos a través del correo: <a href="mailto:contacto@gw2item.com">contacto@gw2item.com</a></p>
     </div>
 
-    <script integrity="sha256-e3+Ub3bujqc4mStLmN8oZtYHu4uZJPmYXFRju6AA6Q8= sha384-sjiNyBsvrZbgC7jV9c37FhMUW3NlFS5w2nNigt+nYWUXUPVQazy72nAB86+1MXxn" crossorigin="anonymous" type="module" src="/dist/1.0.0/bundle-auth-nav.CqVBeA8h.min.js?v=1.0.0"></script>
+    <script integrity="sha256-+bpdjbsjdfS0DsObGV+H5ase5TcRhNbnugV/kPVkOZM= sha384-DF8o1TAyg7iGs+xFx+N04xQpcAVmwBFH8gGs0gK9kBbGB4GreifwOLYeWpmhO5yX" crossorigin="anonymous" type="module" src="/dist/1.0.0/auth-nav.min.js?v=1.0.0"></script>
   <script integrity="sha256-FxLx+TVwUhON5UhF8ODw/UZ34gLsNlgyBGOTHEpSXrM= sha384-mP/SQYle5qV13Ergl1Q8JsstSEkgoty171bfXnrSAV7Zsv/BmMzB0+m5d/IrJj4K" crossorigin="anonymous" type="module" src="/dist/1.0.0/sw-register.Wot8iBZe.min.js?v=1.0.0"></script>
 </body>
 </html>

--- a/random.html
+++ b/random.html
@@ -110,15 +110,8 @@
       </section>
     </main>
   </div>
-  <script integrity="sha256-e3+Ub3bujqc4mStLmN8oZtYHu4uZJPmYXFRju6AA6Q8= sha384-sjiNyBsvrZbgC7jV9c37FhMUW3NlFS5w2nNigt+nYWUXUPVQazy72nAB86+1MXxn" crossorigin="anonymous" type="module" src="/dist/1.0.0/bundle-auth-nav.CqVBeA8h.min.js?v=1.0.0"></script>
-  <script>
-    // Inicializar autenticación cuando el DOM esté listo
-    document.addEventListener('DOMContentLoaded', function() {
-      if (window.Auth && typeof window.Auth.initAuth === 'function') {
-        window.Auth.initAuth();
-      }
-    });
-  </script>
+  <script integrity="sha256-+bpdjbsjdfS0DsObGV+H5ase5TcRhNbnugV/kPVkOZM= sha384-DF8o1TAyg7iGs+xFx+N04xQpcAVmwBFH8gGs0gK9kBbGB4GreifwOLYeWpmhO5yX" crossorigin="anonymous" type="module" src="/dist/1.0.0/auth-nav.min.js?v=1.0.0"></script>
+
   
   <script integrity="sha256-yI6ViVC5KFzl3iJ0vTf6VBnEz4JVDaVP7w/3PC3JtYU= sha384-1SklEHhqxptmXw2WXnv8CR0286+EboqTElpLhFpB1AvjirN2PhxYi2ldKS2TvJzy" crossorigin="anonymous" type="module" src="/dist/1.0.0/feedback-modal.BaGBwUid.min.js?v=1.0.0"></script>
   <script integrity="sha256-FxLx+TVwUhON5UhF8ODw/UZ34gLsNlgyBGOTHEpSXrM= sha384-mP/SQYle5qV13Ergl1Q8JsstSEkgoty171bfXnrSAV7Zsv/BmMzB0+m5d/IrJj4K" crossorigin="anonymous" type="module" src="/dist/1.0.0/sw-register.Wot8iBZe.min.js?v=1.0.0"></script>

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -12,13 +12,15 @@ const noHashEntries = new Set([
   'compareHandlers',
   'cuenta',
   'tabs',
-  'search-modal-core'
+  'search-modal-core',
+  'auth-nav'
 ]);
 
 export default {
   // Entradas separadas para cada vista o funcionalidad pesada
   input: {
     'bundle-auth-nav': 'src/js/bundle-auth-nav.js',
+    'auth-nav': 'src/js/auth-nav.js',
     'bundle-dones': 'src/js/bundle-dones.js',
     'bundle-fractales': 'src/js/bundle-fractales.js',
     'bundle-forja-mistica': 'src/js/bundle-forja-mistica.js',

--- a/sangre-y-hielo.html
+++ b/sangre-y-hielo.html
@@ -70,15 +70,8 @@
       </section>
     </main>
   </div>
-  <script integrity="sha256-e3+Ub3bujqc4mStLmN8oZtYHu4uZJPmYXFRju6AA6Q8= sha384-sjiNyBsvrZbgC7jV9c37FhMUW3NlFS5w2nNigt+nYWUXUPVQazy72nAB86+1MXxn" crossorigin="anonymous" type="module" src="/dist/1.0.0/bundle-auth-nav.CqVBeA8h.min.js?v=1.0.0"></script>
-  <script>
-    // Inicializar autenticación cuando el DOM esté listo
-    document.addEventListener('DOMContentLoaded', function() {
-      if (window.Auth && typeof window.Auth.initAuth === 'function') {
-        window.Auth.initAuth();
-      }
-    });
-  </script>
+  <script integrity="sha256-+bpdjbsjdfS0DsObGV+H5ase5TcRhNbnugV/kPVkOZM= sha384-DF8o1TAyg7iGs+xFx+N04xQpcAVmwBFH8gGs0gK9kBbGB4GreifwOLYeWpmhO5yX" crossorigin="anonymous" type="module" src="/dist/1.0.0/auth-nav.min.js?v=1.0.0"></script>
+
   
   <script integrity="sha256-yI6ViVC5KFzl3iJ0vTf6VBnEz4JVDaVP7w/3PC3JtYU= sha384-1SklEHhqxptmXw2WXnv8CR0286+EboqTElpLhFpB1AvjirN2PhxYi2ldKS2TvJzy" crossorigin="anonymous" type="module" src="/dist/1.0.0/feedback-modal.BaGBwUid.min.js?v=1.0.0"></script>
   <script integrity="sha256-FxLx+TVwUhON5UhF8ODw/UZ34gLsNlgyBGOTHEpSXrM= sha384-mP/SQYle5qV13Ergl1Q8JsstSEkgoty171bfXnrSAV7Zsv/BmMzB0+m5d/IrJj4K" crossorigin="anonymous" type="module" src="/dist/1.0.0/sw-register.Wot8iBZe.min.js?v=1.0.0"></script>

--- a/scripts/check-links.js
+++ b/scripts/check-links.js
@@ -2,6 +2,12 @@ const fs = require('fs');
 const path = require('path');
 
 const rootDir = path.join(__dirname, '..');
+let manifest = {};
+try {
+  manifest = JSON.parse(
+    fs.readFileSync(path.join(rootDir, 'dist', 'manifest.json'), 'utf8')
+  );
+} catch {}
 
 function getHtmlFiles(dir) {
   const entries = fs.readdirSync(dir, { withFileTypes: true });
@@ -27,9 +33,15 @@ function verifyReference(ref, baseDir, filePath) {
     return;
   }
   const cleanRef = ref.split(/[?#]/)[0];
-  const target = ref.startsWith('/')
+  let target = ref.startsWith('/')
     ? path.join(rootDir, cleanRef)
     : path.join(baseDir, cleanRef);
+  if (!fs.existsSync(target)) {
+    const mapped = manifest[cleanRef];
+    if (mapped) {
+      target = path.join(rootDir, mapped);
+    }
+  }
   try {
     fs.accessSync(target);
   } catch {

--- a/secrets-of-the-obscure.html
+++ b/secrets-of-the-obscure.html
@@ -65,15 +65,8 @@
       </section>
     </main>
   </div>
-  <script integrity="sha256-e3+Ub3bujqc4mStLmN8oZtYHu4uZJPmYXFRju6AA6Q8= sha384-sjiNyBsvrZbgC7jV9c37FhMUW3NlFS5w2nNigt+nYWUXUPVQazy72nAB86+1MXxn" crossorigin="anonymous" type="module" src="/dist/1.0.0/bundle-auth-nav.CqVBeA8h.min.js?v=1.0.0"></script>
-  <script>
-    // Inicializar autenticación cuando el DOM esté listo
-    document.addEventListener('DOMContentLoaded', function() {
-      if (window.Auth && typeof window.Auth.initAuth === 'function') {
-        window.Auth.initAuth();
-      }
-    });
-  </script>
+  <script integrity="sha256-+bpdjbsjdfS0DsObGV+H5ase5TcRhNbnugV/kPVkOZM= sha384-DF8o1TAyg7iGs+xFx+N04xQpcAVmwBFH8gGs0gK9kBbGB4GreifwOLYeWpmhO5yX" crossorigin="anonymous" type="module" src="/dist/1.0.0/auth-nav.min.js?v=1.0.0"></script>
+
   
   <script integrity="sha256-yI6ViVC5KFzl3iJ0vTf6VBnEz4JVDaVP7w/3PC3JtYU= sha384-1SklEHhqxptmXw2WXnv8CR0286+EboqTElpLhFpB1AvjirN2PhxYi2ldKS2TvJzy" crossorigin="anonymous" type="module" src="/dist/1.0.0/feedback-modal.BaGBwUid.min.js?v=1.0.0"></script>
   <script integrity="sha256-FxLx+TVwUhON5UhF8ODw/UZ34gLsNlgyBGOTHEpSXrM= sha384-mP/SQYle5qV13Ergl1Q8JsstSEkgoty171bfXnrSAV7Zsv/BmMzB0+m5d/IrJj4K" crossorigin="anonymous" type="module" src="/dist/1.0.0/sw-register.Wot8iBZe.min.js?v=1.0.0"></script>

--- a/sellos-y-runas.html
+++ b/sellos-y-runas.html
@@ -41,15 +41,8 @@
      
     </main>
   </div>
-  <script integrity="sha256-e3+Ub3bujqc4mStLmN8oZtYHu4uZJPmYXFRju6AA6Q8= sha384-sjiNyBsvrZbgC7jV9c37FhMUW3NlFS5w2nNigt+nYWUXUPVQazy72nAB86+1MXxn" crossorigin="anonymous" type="module" src="/dist/1.0.0/bundle-auth-nav.CqVBeA8h.min.js?v=1.0.0"></script>
-  <script>
-    // Inicializar autenticación cuando el DOM esté listo
-    document.addEventListener('DOMContentLoaded', function() {
-      if (window.Auth && typeof window.Auth.initAuth === 'function') {
-        window.Auth.initAuth();
-      }
-    });
-  </script>
+  <script integrity="sha256-+bpdjbsjdfS0DsObGV+H5ase5TcRhNbnugV/kPVkOZM= sha384-DF8o1TAyg7iGs+xFx+N04xQpcAVmwBFH8gGs0gK9kBbGB4GreifwOLYeWpmhO5yX" crossorigin="anonymous" type="module" src="/dist/1.0.0/auth-nav.min.js?v=1.0.0"></script>
+
   
   <script integrity="sha256-yI6ViVC5KFzl3iJ0vTf6VBnEz4JVDaVP7w/3PC3JtYU= sha384-1SklEHhqxptmXw2WXnv8CR0286+EboqTElpLhFpB1AvjirN2PhxYi2ldKS2TvJzy" crossorigin="anonymous" type="module" src="/dist/1.0.0/feedback-modal.BaGBwUid.min.js?v=1.0.0"></script>
   <script integrity="sha256-FxLx+TVwUhON5UhF8ODw/UZ34gLsNlgyBGOTHEpSXrM= sha384-mP/SQYle5qV13Ergl1Q8JsstSEkgoty171bfXnrSAV7Zsv/BmMzB0+m5d/IrJj4K" crossorigin="anonymous" type="module" src="/dist/1.0.0/sw-register.Wot8iBZe.min.js?v=1.0.0"></script>

--- a/src/js/auth-nav.js
+++ b/src/js/auth-nav.js
@@ -1,0 +1,11 @@
+window.addEventListener('DOMContentLoaded', async () => {
+  try {
+    const manifest = await fetch('/dist/manifest.json').then(r => r.json());
+    const path = manifest['/dist/js/bundle-auth-nav.min.js'];
+    if (path) {
+      await import(`${path}?v=${window.__APP_VERSION__}`);
+    }
+  } catch (e) {
+    console.error('Error loading auth module', e);
+  }
+});


### PR DESCRIPTION
## Summary
- bundle auth navigation via dedicated entry and loader
- reference generated auth-nav bundle from HTML using manifest lookup
- improve link checker to resolve paths through manifest

## Testing
- `npm test`
- `node scripts/check-links.js`


------
https://chatgpt.com/codex/tasks/task_e_68be53f2440083289c63e2f102e4a812