### PR TITLE
fix: handle leading slashes in link checker

### DIFF
--- a/scripts/check-links.js
+++ b/scripts/check-links.js
@@ -33,9 +33,10 @@ function verifyReference(ref, baseDir, filePath) {
     return;
   }
   const cleanRef = ref.split(/[?#]/)[0];
-  let target = ref.startsWith('/')
-    ? path.join(rootDir, cleanRef)
+  const resolved = cleanRef.startsWith('/')
+    ? path.join(rootDir, cleanRef.slice(1))
     : path.join(baseDir, cleanRef);
+  let target = resolved;
   if (!fs.existsSync(target)) {
     const mapped = manifest[cleanRef];
     if (mapped) {


### PR DESCRIPTION
## Summary
- ensure check-links resolves references with leading slash correctly

## Testing
- `npm test`
- `npm run check-links`


------
https://chatgpt.com/codex/tasks/task_e_68be7c953f0c8328b4c62b329abbf59c