### PR TITLE
ci: build before checking links

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -13,4 +13,5 @@ jobs:
         with:
           node-version: 20
       - run: npm ci
+      - run: npm run build
       - run: npm run check-links


### PR DESCRIPTION
## Summary
- ensure `check-links` workflow builds project before checking links

## Testing
- `npm ci` *(fails: Unknown env config "http-proxy" and did not complete)*
- `npm run build` *(fails: tsup: not found)*
- `npm run check-links` *(fails: Missing references /dist/1.0.0/*)*
- `npm test` *(fails: tsup: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bee751ae048328ab076d3a5d5b7590