### PR TITLE
fix: validar resumenData antes de su uso

### DIFF
--- a/fractales-gold.html
+++ b/fractales-gold.html
@@ -199,9 +199,11 @@
         await ui.renderTablaPrecios();
         const resumenData = await ui.renderTablaResumenOro('tabla-resumen-oro', preciosFractales);
         await ui.renderTablaResumenOroIndividual('tabla-resumen-oro-individual', preciosFractales);
-        ui.renderGraficoContribuciones(resumenData.contribuciones);
-        ui.renderTablaReferenciasProfit('tabla-referencias-profit', preciosFractales, resumenData);
-        ui.renderGraficoAbrirVsVender('abrir-vs-vender-chart', preciosFractales, resumenData);
+        if (resumenData) {
+          ui.renderGraficoContribuciones(resumenData.contribuciones);
+          ui.renderTablaReferenciasProfit('tabla-referencias-profit', preciosFractales, resumenData);
+          ui.renderGraficoAbrirVsVender('abrir-vs-vender-chart', preciosFractales, resumenData);
+        }
         ui.renderExtras(preciosFractales, 24.96);
       }
 


### PR DESCRIPTION
## Summary
- Envolver llamadas que usan `resumenData` con una comprobación `if (resumenData)`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bfa58f27808328aa0413e45f86cbf6