### PR TITLE
Resolve costs worker items-core by version

### DIFF
--- a/dist/1.0.0/workers/costsWorker.js
+++ b/dist/1.0.0/workers/costsWorker.js
@@ -1,4 +1,12 @@
-import { CraftIngredient } from '../items-core.C2UiOsx8.min.js';
+export {};
+let CraftIngredient;
+if (typeof self === 'undefined') {
+  ({ CraftIngredient } = await import('../items-core.js'));
+} else {
+  const manifest = await fetch('/dist/manifest.json').then(r => r.json()).catch(() => ({}));
+  const itemsCorePath = manifest['/dist/js/items-core.min.js'] || `../items-core.${self.__APP_VERSION__}.min.js`;
+  ({ CraftIngredient } = await import(itemsCorePath));
+}
 
 const ctx = typeof self !== 'undefined' ? self : globalThis;
 

--- a/src/js/workers/costsWorker.js
+++ b/src/js/workers/costsWorker.js
@@ -1,103 +1,12 @@
-class CraftIngredient {
-  constructor({id, name, icon, rarity, count, buy_price, sell_price, is_craftable, recipe, children = [], _parentId = null}) {
-    this._uid = CraftIngredient.nextUid++;
-    this.id = id;
-    this.name = name;
-    this.icon = icon;
-    this.rarity = rarity;
-    this.count = count;
-    this.buy_price = buy_price;
-    this.sell_price = sell_price;
-    this.is_craftable = is_craftable;
-    this.recipe = recipe || null;
-    this.children = children;
-    this.mode = 'buy';
-    this.modeForParentCrafted = 'buy';
-    this.expanded = false;
-    this._parentId = _parentId;
-    this._parent = null;
-    this.countTotal = 0;
-    this.crafted_price = null;
-    this.total_buy = 0;
-    this.total_sell = 0;
-    this.total_crafted = 0;
-  }
-
-  findRoot() {
-    let current = this;
-    while (current._parent) current = current._parent;
-    return current;
-  }
-
-  setMode(newMode) {
-    if (['buy', 'sell', 'crafted'].includes(newMode)) {
-      this.modeForParentCrafted = newMode;
-      const root = this.findRoot();
-      root.recalc(globalThis.globalQty || 1, null);
-      if (typeof globalThis.safeRenderTable === 'function') globalThis.safeRenderTable();
-    }
-  }
-
-  recalc(globalQty = 1, parent = null) {
-    const isRoot = parent == null;
-    const isMysticCloverSpecial = this.id === 19675 && (this.count === 77 || this.count === 38);
-    if (isRoot) {
-      this.countTotal = this.count * globalQty;
-    } else if (isMysticCloverSpecial) {
-      this.countTotal = this.count;
-    } else {
-      this.countTotal = parent.countTotal * this.count;
-    }
-
-    if (this.children && this.children.length > 0) {
-      if (isMysticCloverSpecial) {
-        const manualCounts = this.count === 77 ? [250, 250, 250, 1500] : [38, 38, 38, 38];
-        this.children.forEach((child, idx) => {
-          child.countTotal = manualCounts[idx] || 0;
-          child.total_buy = (child.buy_price || 0) * child.countTotal;
-          child.total_sell = (child.sell_price || 0) * child.countTotal;
-        });
-      } else {
-        this.children.forEach(child => child.recalc(globalQty, this));
-      }
-    }
-
-    if (isRoot || isMysticCloverSpecial) {
-      this.total_buy = this.children.reduce((s, c) => s + (c.total_buy || 0), 0);
-      this.total_sell = this.children.reduce((s, c) => s + (c.total_sell || 0), 0);
-    } else {
-      this.total_buy = (this.buy_price || 0) * this.countTotal;
-      this.total_sell = (this.sell_price || 0) * this.countTotal;
-    }
-
-    if (this.is_craftable && this.children.length > 0) {
-      this.total_crafted = this.children.reduce((sum, ing) => {
-        switch (ing.modeForParentCrafted) {
-          case 'sell': return sum + (ing.total_sell || 0);
-          case 'crafted': return sum + (ing.total_crafted || 0);
-          default: return sum + (ing.total_buy || 0);
-        }
-      }, 0);
-      this.crafted_price = this.total_crafted / (this.recipe?.output_item_count || 1);
-
-      if (!isRoot && (!this.buy_price && !this.sell_price)) {
-        this.total_buy = this.children.reduce((s, c) => s + (c.total_buy || 0), 0);
-        this.total_sell = this.children.reduce((s, c) => s + (c.total_sell || 0), 0);
-      }
-    } else {
-      this.total_crafted = null;
-      this.crafted_price = null;
-    }
-  }
-
-  getBestPrice() {
-    if (typeof this.buy_price === 'number' && this.buy_price > 0) return this.buy_price;
-    if (typeof this.crafted_price === 'number' && this.crafted_price > 0) return this.crafted_price;
-    return 0;
-  }
+export {};
+let CraftIngredient;
+if (typeof self === 'undefined') {
+  ({ CraftIngredient } = await import('../items-core.js'));
+} else {
+  const manifest = await fetch('/dist/manifest.json').then(r => r.json()).catch(() => ({}));
+  const itemsCorePath = manifest['/dist/js/items-core.min.js'] || `../items-core.${self.__APP_VERSION__}.min.js`;
+  ({ CraftIngredient } = await import(itemsCorePath));
 }
-
-CraftIngredient.nextUid = 0;
 
 const ctx = typeof self !== 'undefined' ? self : globalThis;
 


### PR DESCRIPTION
## Summary
- load `items-core` in `costsWorker` using manifest lookup or app version, avoiding hardcoded hash

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bfcf9bc6f483288e6891fa2f375ac7