### PR TITLE
fix(costsWorker): use versioned items-core path

### DIFF
--- a/dist/1.0.0/workers/costsWorker.js
+++ b/dist/1.0.0/workers/costsWorker.js
@@ -1,7 +1,7 @@
 export {};
 let CraftIngredient;
 if (typeof self === 'undefined') {
-  ({ CraftIngredient } = await import('../items-core.js'));
+  ({ CraftIngredient } = await import('../items-core.C2UiOsx8.min.js'));
 } else {
   const manifest = await fetch('/dist/manifest.json').then(r => r.json()).catch(() => ({}));
   const itemsCorePath = manifest['/dist/js/items-core.min.js'] || `../items-core.${self.__APP_VERSION__}.min.js`;


### PR DESCRIPTION
## Summary
- use minified items-core file in costsWorker for consistency

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bfd2b298f08328841b46b812290e6f